### PR TITLE
Use last modified time instead of last accessed time

### DIFF
--- a/bytemark-restore
+++ b/bytemark-restore
@@ -105,7 +105,7 @@ foreach my $loopvariable(@$ls)
                 {
                         my $innername = $innerloopvariable->{filename};
                         my $a = $innerloopvariable->{a};
-                        my $time = $a->{'atime'};
+                        my $time = $a->{'mtime'};
                         $fmtdate = time2str("%Y-%m-%d-%H_%m_%S",$time);
                         my $obj = {filename => $innerloopvariable->{filename}, number => $cnt, name => $name, fmtdate => $fmtdate };
                         $optionsh{$time} = $obj;


### PR DESCRIPTION
Using `atime` returns the following for a file search (these dates could be confusing for a customer):

<pre>
.-------+------------+----------------------.
| Match | Directory  | Date                 |
+-------+------------+----------------------+
| 1     | weekly.3   | 2018-04-26-14_04_37  |
| 2     | weekly.2   | 2018-05-03-14_05_41  |
| 3     | weekly.1   | 2018-05-10-14_05_31  |
| 4     | weekly.0   | 2018-05-17-14_05_47  |
| 5     | daily.6    | 2018-05-18-14_05_55  |
| 6     | daily.5    | 2018-05-19-14_05_53  |
| 7     | daily.4    | 2018-05-20-14_05_03  |
| 8     | daily.3    | 2018-05-21-14_05_44  |
| 9     | daily.2    | 2018-05-22-14_05_54  |
| 10    | daily.1    | 2018-05-23-14_05_46  |
| 11    | daily.0    | 2018-05-23-14_05_47  |
'-------+------------+----------------------'
</pre>

Whereas `mtime` returns the following, with dates sorted from oldest to newest based on times the backups took place:

<pre>
.-------+------------+----------------------.
| Match | Directory  | Date                 |
+-------+------------+----------------------+
| 1     | weekly.3   | 2018-04-25-01_04_39  |
| 2     | weekly.2   | 2018-05-02-01_05_19  |
| 3     | weekly.1   | 2018-05-09-01_05_12  |
| 4     | weekly.0   | 2018-05-16-01_05_39  |
| 5     | daily.6    | 2018-05-17-01_05_17  |
| 6     | daily.5    | 2018-05-18-01_05_40  |
| 7     | daily.4    | 2018-05-19-01_05_50  |
| 8     | daily.3    | 2018-05-20-01_05_37  |
| 9     | daily.2    | 2018-05-21-01_05_01  |
| 10    | daily.1    | 2018-05-22-01_05_52  |
| 11    | daily.0    | 2018-05-23-01_05_44  |
'-------+------------+----------------------'
</pre>